### PR TITLE
fix: fetch tags in checkout action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
           # NOTE: our versioning scheme depends on git tags, so it's kinda
           # important to fetch tags here
           fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
@@ -85,6 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   release:
+    if: false
     name: Release
     runs-on: ubuntu-latest
     permissions:
@@ -31,13 +32,17 @@ jobs:
         run: npx semantic-release@24
   push-components:
     name: Push KFP Components
-    needs: release
+    # needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # NOTE: our versioning scheme depends on git tags, so it's kinda
+          # important to fetch tags here
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
@@ -68,13 +73,15 @@ jobs:
             gs://pipelines-from-scratch-kfp-component-metadata-ea624a34/$(pipx run hatch version)/
   push-pipeline:
     name: Push Pipeline Specs
-    needs: release
+    # needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   repository_dispatch:
     types: [semantic-release]
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,15 +3,11 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
   repository_dispatch:
     types: [semantic-release]
   workflow_dispatch:
 jobs:
   release:
-    if: false
     name: Release
     runs-on: ubuntu-latest
     permissions:
@@ -35,7 +31,7 @@ jobs:
         run: npx semantic-release@24
   push-components:
     name: Push KFP Components
-    # needs: release
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -77,7 +73,7 @@ jobs:
             gs://pipelines-from-scratch-kfp-component-metadata-ea624a34/$(pipx run hatch version)/
   push-pipeline:
     name: Push Pipeline Specs
-    # needs: release
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'


### PR DESCRIPTION
Our versioning software (hatch_vcs) uses git tags to infer the current package version.
This makes it necessary to fetch tags in CI so that the python package picks up the correct version.